### PR TITLE
Statically require fileutils for newer ruby support

### DIFF
--- a/lib/capistrano/s3/publisher.rb
+++ b/lib/capistrano/s3/publisher.rb
@@ -1,5 +1,6 @@
 require 'aws/s3'
 require 'mime/types'
+require 'fileutils'
 
 module Publisher
 


### PR DESCRIPTION
Fixes:

```
/usr/local/lib/ruby/gems/1.9.1/gems/capistrano-s3-0.2.5/lib/capistrano/s3/publisher.rb:36:in `publish!': uninitialized constant Publisher::FileUtils (NameError)
    from /usr/local/lib/ruby/gems/1.9.1/gems/capistrano-s3-0.2.5/lib/capistrano/s3.rb:26:in `block (4 levels) in <top (required)>'
    from /usr/local/lib/ruby/gems/1.9.1/gems/capistrano-2.13.5/lib/capistrano/configuration/execution.rb:138:in `instance_eval'
    from /usr/local/lib/ruby/gems/1.9.1/gems/capistrano-2.13.5/lib/capistrano/configuration/execution.rb:138:in `invoke_task_directly'
    from /usr/local/lib/ruby/gems/1.9.1/gems/capistrano-2.13.5/lib/capistrano/configuration/callbacks.rb:25:in `invoke_task_directly_with_callbacks'
    from /usr/local/lib/ruby/gems/1.9.1/gems/capistrano-2.13.5/lib/capistrano/configuration/execution.rb:89:in `execute_task'
    from /usr/local/lib/ruby/gems/1.9.1/gems/capistrano-2.13.5/lib/capistrano/configuration/namespaces.rb:191:in `method_missing'
    from /usr/local/lib/ruby/gems/1.9.1/gems/capistrano-2.13.5/lib/capistrano/configuration/namespaces.rb:191:in `method_missing'
    from /usr/local/lib/ruby/gems/1.9.1/gems/capistrano-2.13.5/lib/capistrano/configuration/namespaces.rb:110:in `block in define_task'
    from /usr/local/lib/ruby/gems/1.9.1/gems/capistrano-s3-0.2.5/lib/capistrano/s3.rb:31:in `block (3 levels) in <top (required)>'
    from /usr/local/lib/ruby/gems/1.9.1/gems/capistrano-2.13.5/lib/capistrano/configuration/execution.rb:138:in `instance_eval'
    from /usr/local/lib/ruby/gems/1.9.1/gems/capistrano-2.13.5/lib/capistrano/configuration/execution.rb:138:in `invoke_task_directly'
    from /usr/local/lib/ruby/gems/1.9.1/gems/capistrano-2.13.5/lib/capistrano/configuration/callbacks.rb:25:in `invoke_task_directly_with_callbacks'
    from /usr/local/lib/ruby/gems/1.9.1/gems/capistrano-2.13.5/lib/capistrano/configuration/execution.rb:89:in `execute_task'
    from /usr/local/lib/ruby/gems/1.9.1/gems/capistrano-2.13.5/lib/capistrano/configuration/namespaces.rb:191:in `method_missing'
    from /usr/local/lib/ruby/gems/1.9.1/gems/capistrano-2.13.5/lib/capistrano/configuration/namespaces.rb:110:in `block in define_task'
    from /usr/local/lib/ruby/gems/1.9.1/gems/capistrano-2.13.5/lib/capistrano/recipes/deploy.rb:195:in `block (2 levels) in load'
    from /usr/local/lib/ruby/gems/1.9.1/gems/capistrano-2.13.5/lib/capistrano/configuration/execution.rb:138:in `instance_eval'
    from /usr/local/lib/ruby/gems/1.9.1/gems/capistrano-2.13.5/lib/capistrano/configuration/execution.rb:138:in `invoke_task_directly'
    from /usr/local/lib/ruby/gems/1.9.1/gems/capistrano-2.13.5/lib/capistrano/configuration/callbacks.rb:25:in `invoke_task_directly_with_callbacks'
    from /usr/local/lib/ruby/gems/1.9.1/gems/capistrano-2.13.5/lib/capistrano/configuration/execution.rb:89:in `execute_task'
    from /usr/local/lib/ruby/gems/1.9.1/gems/capistrano-2.13.5/lib/capistrano/configuration/execution.rb:101:in `find_and_execute_task'
    from /usr/local/lib/ruby/gems/1.9.1/gems/capistrano-2.13.5/lib/capistrano/cli/execute.rb:46:in `block in execute_requested_actions'
    from /usr/local/lib/ruby/gems/1.9.1/gems/capistrano-2.13.5/lib/capistrano/cli/execute.rb:45:in `each'
    from /usr/local/lib/ruby/gems/1.9.1/gems/capistrano-2.13.5/lib/capistrano/cli/execute.rb:45:in `execute_requested_actions'
    from /usr/local/lib/ruby/gems/1.9.1/gems/capistrano-2.13.5/lib/capistrano/cli/help.rb:19:in `execute_requested_actions_with_help'
    from /usr/local/lib/ruby/gems/1.9.1/gems/capistrano-2.13.5/lib/capistrano/cli/execute.rb:34:in `execute!'
    from /usr/local/lib/ruby/gems/1.9.1/gems/capistrano-2.13.5/lib/capistrano/cli/execute.rb:14:in `execute'
    from /usr/local/lib/ruby/gems/1.9.1/gems/capistrano-2.13.5/bin/cap:4:in `<top (required)>'
    from /usr/local/bin/cap:23:in `load'
    from /usr/local/bin/cap:23:in `<main>'
```
