### PR TITLE
Pass a string to the content_type option

### DIFF
--- a/lib/capistrano/s3/publisher.rb
+++ b/lib/capistrano/s3/publisher.rb
@@ -26,7 +26,7 @@ module Publisher
         else
           options = {
             :acl => :public_read,
-            :content_type => types[0]
+            :content_type => types.first.content_type
           }
         end
         options.merge!(extra_options)


### PR DESCRIPTION
We noticed that css files were getting their "Content-Type" header set as empty. This isn't a problem with modern browsers, but IE won't play nice.

Experimenting with how to get the mime type of a file, since there are a lots of ways, we ended up using `types.first.content_type` instead of `types[0]`. This returns a string, instead of an object, which for whatever reason fixes the issue. All other content types are still set as expected.

Tested against `ruby 2.0.0p0 (2013-02-24 revision 39474) [x86_64-darwin12.2.0]`.
## Output Examples

Before:

```
I, [2013-04-01T11:20:03.782420 #11532]  INFO -- : [AWS S3 200 0.183128 0 retries] put_object(:acl=>"private",:bucket_name=>"staging.greatcaloriedrive.com",:content_length=>723,:content_type=>#<MIME::Type:0x007f917a5b66d0 @content_type="text/css", @raw_media_type="text", @raw_sub_type="css", @simplified="text/css", @media_type="text", @sub_type="css", @extensions=["css"], @encoding="8bit", @system=nil, @registered=true, @url=["IANA", "RFC2318"], @obsolete=nil, @docs=nil>,:data=>#<File:/Users/douglasjarquin/Repos/zumba/gcd/public/en/styles/en.css (723 bytes)>,:key=>"en/styles/en.css")  
```

After:

```
I, [2013-04-01T11:21:19.602401 #11642]  INFO -- : [AWS S3 200 0.195902 0 retries] put_object(:acl=>"private",:bucket_name=>"staging.greatcaloriedrive.com",:content_length=>723,:content_type=>"text/css",:data=>#<File:/Users/douglasjarquin/Repos/zumba/gcd/public/en/styles/en.css (723 bytes)>,:key=>"en/styles/en.css")
```
