### PR TITLE
Adds ability to specify redirect location for files

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,19 @@ If you want to deploy to multiple buckets, have a look at
 [Capistrano multistage](https://github.com/capistrano/capistrano/wiki/2.x-Multistage-Extension)
 and configure a bucket per stage configuration.
 
+#### Redirecting
+
+Use `:redirect_options` to natively redirect (via HTTP 301 status code)
+any hosted page. For example:
+```ruby
+set :redirect_options, {
+  'index.html' => 'http://example.org',
+  'another.html' => '/test.html',
+}
+```
+Valid redirect destination should either start with `http` or `https` scheme,
+or begin with leading slash `/`.
+
 #### S3 write options
 
 capistrano-s3 sets files `:content_type` and `:acl` to `:public_read`, add or override with :
@@ -70,9 +83,9 @@ set :bucket_write_options, {
 }
 ```
 
-See aws-sdk [S3Object.write doc](http://docs.aws.amazon.com/AWSRubySDK/latest/AWS/S3/S3Object.html#write-instance_method) for all available options.
+See aws-sdk [S3Client.put_object doc](http://docs.aws.amazon.com/AWSRubySDK/latest/AWS/S3/Client.html#put_object-instance_method) for all available options.
 
-## Exemple of usage
+## Example of usage
 
 Our Ruby stack for static websites :
 
@@ -90,7 +103,9 @@ before 'deploy' do
 end
 ```
 
-See our boilerplate [sinatra-static-bp](https://github.com/hooktstudios/sinatra-static-bp) for an exemple of the complete setup.
+See our boilerplate
+[sinatra-static-bp](https://github.com/hooktstudios/sinatra-static-bp)
+for an example of the complete setup.
 
 ## Contributing
 

--- a/lib/capistrano/s3.rb
+++ b/lib/capistrano/s3.rb
@@ -2,33 +2,35 @@ require 'capistrano'
 require 'capistrano/s3/publisher'
 
 unless Capistrano::Configuration.respond_to?(:instance)
-  abort "capistrano-s3 requires Capistrano >= 2."
+  abort "capistrano-s3 requires Capistrano 2.0 or newer"
 end
 
 Capistrano::Configuration.instance(true).load do
   def _cset(name, *args, &block)
     set(name, *args, &block) if !exists?(name)
   end
-  
+
   _cset :deployment_path, Dir.pwd.gsub("\n", "") + "/public"
   _cset :bucket_write_options, :acl => :public_read
   _cset :s3_endpoint, 's3.amazonaws.com'
-  
+  _cset :redirect_options, {}
+
   # Deployment recipes
   namespace :deploy do
-    namespace :s3 do      
+    namespace :s3 do
       desc "Empties bucket of all files. Caution when using this command, as it cannot be undone!"
       task :empty do
-        Publisher.clear!(s3_endpoint, access_key_id, secret_access_key)
+        Publisher.clear!(s3_endpoint, access_key_id, secret_access_key, bucket)
       end
 
       desc "Upload files to the bucket in the current state"
       task :upload_files do
+        extra_options = { :write => bucket_write_options, :redirect => redirect_options }
         Publisher.publish!(s3_endpoint, access_key_id, secret_access_key,
-                           bucket, deployment_path, bucket_write_options)
+                           bucket, deployment_path, extra_options)
       end
     end
-    
+
     task :update do
       s3.upload_files
     end

--- a/lib/capistrano/s3/publisher.rb
+++ b/lib/capistrano/s3/publisher.rb
@@ -7,7 +7,7 @@ module Publisher
   LAST_PUBLISHED_FILE = '.last_published'
 
   def self.publish!(s3_endpoint, key, secret, bucket, source, extra_options)
-    s3 = self.establish_connection!(s3_endpoint, key, secret)
+    s3 = self.establish_s3_client_connection!(s3_endpoint, key, secret)
 
     self.files(source).each do |file|
       if !File.directory?(file)
@@ -16,21 +16,7 @@ module Publisher
         path = self.base_file_path(source, file)
         path.gsub!(/^\//, "") # Remove preceding slash for S3
 
-        contents = open(file)
-
-        types = MIME::Types.type_for(File.basename(file))
-        if types.empty?
-          options = {
-            :acl => :public_read
-          }
-        else
-          options = {
-            :acl => :public_read,
-            :content_type => types.first.content_type
-          }
-        end
-        options.merge!(extra_options)
-        s3.buckets[bucket].objects[path].write(contents, options)
+        self.put_object(s3, bucket, path, file, extra_options)
       end
     end
 
@@ -38,27 +24,37 @@ module Publisher
   end
 
   def self.clear!(s3_endpoint, key, secret, bucket)
-    s3 = self.establish_connection!(s3_endpoint, key, secret)
+    s3 = self.establish_s3_connection!(s3_endpoint, key, secret)
     s3.buckets[bucket].clear!
+
+    FileUtils.rm(LAST_PUBLISHED_FILE)
   end
 
   private
 
     # Establishes the connection to Amazon S3
-    def self.establish_connection!(s3_endpoint, key, secret)
+    def self.establish_connection!(klass, s3_endpoint, key, secret)
       # Send logging to STDOUT
       AWS.config(:logger => Logger.new(STDOUT))
-      AWS::S3.new(
+      klass.new(
         :s3_endpoint => s3_endpoint,
         :access_key_id => key,
         :secret_access_key => secret
       )
     end
 
+    def self.establish_s3_client_connection!(s3_endpoint, key, secret)
+      self.establish_connection!(AWS::S3::Client, s3_endpoint, key, secret)
+    end
+
+    def self.establish_s3_connection!(s3_endpoint, key, secret)
+      self.establish_connection!(AWS::S3, s3_endpoint, key, secret)
+    end
+
     def self.base_file_path(root, file)
       file.gsub(root, "")
     end
-  
+
     def self.files(deployment_path)
       Dir.glob("#{deployment_path}/**/*")
     end
@@ -66,5 +62,33 @@ module Publisher
     def self.published?(file)
       return false unless File.exists? LAST_PUBLISHED_FILE
       File.mtime(file) < File.mtime(LAST_PUBLISHED_FILE)
+    end
+
+    def self.put_object(s3, bucket, path, file, extra_options)
+      options = {
+        :bucket_name => bucket,
+        :key => path,
+        :data => open(file),
+        :acl => :public_read,
+      }
+
+      options.merge!( self.build_content_type_hash(file) )
+      options.merge!( self.build_redirect_hash(path, extra_options[:redirect]) )
+      options.merge!(extra_options[:write])
+
+      s3.put_object(options)
+    end
+
+    def self.build_content_type_hash(file)
+      type = MIME::Types.type_for(File.basename(file))
+      return unless type
+
+      { :content_type => type.first.content_type }
+    end
+
+    def self.build_redirect_hash(path, redirect_options)
+      return unless redirect_options
+
+      { :website_redirect_location => redirect_options[path] }
     end
 end


### PR DESCRIPTION
Other than the new redirection feature, pull request changes `s3` object for `cap deploy` task from 

``` ruby
AWS::S3
```

to

``` ruby
AWS::S3::Client
```

This change is intentional, as former class doesn't allow to specify redirection metadata header in `S3Object#write` method, thus it was necessary to use `S3Client#put_object` method for upload.

Also there are minor refactorings, renamings and bug fixes to various parts of gem.
