### PR TITLE
support non-standard file extensions

### DIFF
--- a/lib/capistrano/s3/publisher.rb
+++ b/lib/capistrano/s3/publisher.rb
@@ -81,7 +81,7 @@ module Publisher
 
     def self.build_content_type_hash(file)
       type = MIME::Types.type_for(File.basename(file))
-      return {} unless type
+      return {} unless type && !type.empty?
 
       { :content_type => type.first.content_type }
     end


### PR DESCRIPTION
issue jquery.min.map has a non-standard extension.

when a mime-type is not available the `MIME::Types.type_for(file)` returns an empty array the causes `type.first.content_type` to raise `undefined method`content_type' for nil:NilClass (NoMethodError)`exception
further control`!type.empty?` resolves the issue

You can say that I should use a public cdn for the jQuery library but it's only an example for a non-standard file extension
