### PR TITLE
hotfix uninitialized constant Capistrano::S3

### DIFF
--- a/lib/capistrano/s3.rb
+++ b/lib/capistrano/s3.rb
@@ -1,6 +1,6 @@
 require 'capistrano'
-require 'capistrano/s3/publisher'
 require 'capistrano/s3/version'
+require 'capistrano/s3/publisher'
 
 module Capistrano
   unless Configuration.respond_to?(:instance)


### PR DESCRIPTION
This fixes the following error:
`.../publisher.rb:5:in `<top (required)>': uninitialized constant Capistrano::S3 (NameError)`
by defining the module `Capistrano::S3` before trying to define the module `Capistrano::S3::Publisher`
