### PR TITLE
Set :content_encoding for gzip files.

### DIFF
--- a/lib/capistrano/s3/publisher.rb
+++ b/lib/capistrano/s3/publisher.rb
@@ -74,6 +74,7 @@ module Capistrano::S3::Publisher
 
       options.merge!(self.build_content_type_hash(file))
       options.merge!(self.build_redirect_hash(path, extra_options[:redirect]))
+      options.merge!(self.set_content_encoding_for_gzip(file))
       options.merge!(extra_options[:write]) if extra_options[:write]
 
       s3.put_object(options)
@@ -90,5 +91,15 @@ module Capistrano::S3::Publisher
       return {} unless redirect_options && redirect_options[path]
 
       { :website_redirect_location => redirect_options[path] }
+    end
+
+    def self.set_content_encoding_for_gzip(file)
+      type = MIME::Types.type_for(File.basename(file))
+      if type && !type.empty?
+        if type.first.sub_type == "gzip"
+          return { :content_encoding => "gzip" }
+        end
+      end
+      {}
     end
 end

--- a/lib/capistrano/s3/publisher.rb
+++ b/lib/capistrano/s3/publisher.rb
@@ -97,7 +97,7 @@ module Capistrano::S3::Publisher
       type = MIME::Types.type_for(File.basename(file))
       if type && !type.empty?
         if type.first.sub_type == "gzip"
-          return { :content_encoding => "gzip" }
+          return { :content_encoding => "gzip" } if File.exist? file.gsub /\.gz$/, ""
         end
       end
       {}


### PR DESCRIPTION
This way they become available for clients with the "Accept-Encoding: gzip" header and served in place of uncompressed files.