### PR TITLE
Add `wait_for_invalidation` task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.gem
 .last_published
+.last_invalidation
 Gemfile.lock

--- a/README.md
+++ b/README.md
@@ -77,14 +77,14 @@ Add content to your public folder and run deploy command:
 
 ## Advanced options
 
-### Custom endpoint
+### Custom region
 
 If your bucket is not in the default US Standard region,
-set [endpoint](http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)
+set [region](http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)
 with:
 
 ```ruby
-set :s3_endpoint, 's3-eu-west-1.amazonaws.com'
+set :region, 'eu-west-1'
 ```
 
 ### Write options
@@ -138,6 +138,8 @@ If you set a CloudFront distribution ID (not the URL!) and an array of paths, ca
 set :distribution_id, "CHANGETHIS"
 set :invalidations, [ "/index.html", "/assets/*" ]
 ```
+
+If you want to wait until the invalidation batch is completed (e.g. on a CI server), you can run `cap <stage> deploy:s3:wait_for_invalidation`. The command will wait indefinitely until the invalidation is completed.
 
 ### Exclude files and directories
 

--- a/capistrano-s3.gemspec
+++ b/capistrano-s3.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.1"
 
   # Gem dependencies
-  s.add_runtime_dependency 'aws-sdk',    '~> 1.11'
+  s.add_runtime_dependency 'aws-sdk',    '~> 2.6'
   s.add_runtime_dependency 'capistrano', '>= 2'
   s.add_runtime_dependency 'mime-types', '~> 1.23'
   s.add_runtime_dependency 'net-ssh',    '~> 2.9'

--- a/lib/capistrano/s3/defaults.rb
+++ b/lib/capistrano/s3/defaults.rb
@@ -4,7 +4,7 @@ module Capistrano
       DEFAULTS = {
         :deployment_path      => proc { Dir.pwd.gsub("\n", "") + "/public" },
         :bucket_write_options => { :acl => :public_read },
-        :s3_endpoint          => "s3.amazonaws.com",
+        :region               => 'us-east-1',
         :redirect_options     => {},
         :only_gzip            => false,
         :invalidations        => [],

--- a/lib/capistrano/tasks/capistrano_2.rb
+++ b/lib/capistrano/tasks/capistrano_2.rb
@@ -11,13 +11,18 @@ module Capistrano
       namespace :s3 do
         desc "Empties bucket of all files. Caution when using this command, as it cannot be undone!"
         task :empty do
-          S3::Publisher.clear!(s3_endpoint, access_key_id, secret_access_key, bucket)
+          S3::Publisher.clear!(region, access_key_id, secret_access_key, bucket)
+        end
+
+        desc "Waits until the last CloudFront invalidation batch is completed"
+        task :wait_for_invalidation do
+          S3::Publisher.check_invalidation(region, access_key_id, secret_access_key, distribution_id)
         end
 
         desc "Upload files to the bucket in the current state"
         task :upload_files do
           extra_options = { :write => bucket_write_options, :redirect => redirect_options }
-          S3::Publisher.publish!(s3_endpoint, access_key_id, secret_access_key,
+          S3::Publisher.publish!(region, access_key_id, secret_access_key,
                              bucket, deployment_path, distribution_id, invalidations, exclusions, only_gzip, extra_options)
         end
       end

--- a/lib/capistrano/tasks/capistrano_3.rb
+++ b/lib/capistrano/tasks/capistrano_3.rb
@@ -8,13 +8,18 @@ namespace :deploy do
   namespace :s3 do
     desc "Empties bucket of all files. Caution when using this command, as it cannot be undone!"
     task :empty do
-      Capistrano::S3::Publisher.clear!(fetch(:s3_endpoint), fetch(:access_key_id), fetch(:secret_access_key), fetch(:bucket))
+      Capistrano::S3::Publisher.clear!(fetch(:region), fetch(:access_key_id), fetch(:secret_access_key), fetch(:bucket))
+    end
+
+    desc "Waits until the last CloudFront invalidation batch is completed"
+    task :wait_for_invalidation do
+      Capistrano::S3::Publisher.check_invalidation(fetch(:region), fetch(:access_key_id), fetch(:secret_access_key), fetch(:distribution_id))
     end
 
     desc "Upload files to the bucket in the current state"
     task :upload_files do
       extra_options = { :write => fetch(:bucket_write_options), :redirect => fetch(:redirect_options) }
-      Capistrano::S3::Publisher.publish!(fetch(:s3_endpoint), fetch(:access_key_id), fetch(:secret_access_key),
+      Capistrano::S3::Publisher.publish!(fetch(:region), fetch(:access_key_id), fetch(:secret_access_key),
                              fetch(:bucket), fetch(:deployment_path), fetch(:distribution_id), fetch(:invalidations), fetch(:exclusions), fetch(:only_gzip), extra_options)
     end
   end

--- a/spec/publisher_spec.rb
+++ b/spec/publisher_spec.rb
@@ -9,14 +9,14 @@ describe Capistrano::S3::Publisher do
 
   context "on publish!" do
     it "publish all files" do
-      AWS::S3::Client::V20060301.any_instance.expects(:put_object).times(8)
+      Aws::S3::Client.any_instance.expects(:put_object).times(8)
 
       path = File.join(@root, 'sample')
       Capistrano::S3::Publisher.publish!('s3.amazonaws.com', 'abc', '123', 'mybucket.amazonaws.com', path, 'cf123', [], [], false, {})
     end
 
     it "publish only gzip files when option is enabled" do
-      AWS::S3::Client::V20060301.any_instance.expects(:put_object).times(4)
+      Aws::S3::Client.any_instance.expects(:put_object).times(4)
 
       path = File.join(@root, 'sample')
       Capistrano::S3::Publisher.publish!('s3.amazonaws.com', 'abc', '123', 'mybucket.amazonaws.com', path, 'cf123', [], [], true, {})
@@ -24,16 +24,16 @@ describe Capistrano::S3::Publisher do
 
     context "invalidations" do
       it "publish all files with invalidations" do
-        AWS::S3::Client::V20060301.any_instance.expects(:put_object).times(8)
-        AWS::CloudFront::Client::V20141106.any_instance.expects(:create_invalidation).once
+        Aws::S3::Client.any_instance.expects(:put_object).times(8)
+        Aws::CloudFront::Client.any_instance.expects(:create_invalidation).once
 
         path = File.join(@root, 'sample')
         Capistrano::S3::Publisher.publish!('s3.amazonaws.com', 'abc', '123', 'mybucket.amazonaws.com', path, 'cf123', ['*'], [], false, {})
       end
 
       it "publish all files without invalidations" do
-        AWS::S3::Client::V20060301.any_instance.expects(:put_object).times(8)
-        AWS::CloudFront::Client::V20141106.any_instance.expects(:create_invalidation).never
+        Aws::S3::Client.any_instance.expects(:put_object).times(8)
+        Aws::CloudFront::Client.any_instance.expects(:create_invalidation).never
 
         path = File.join(@root, 'sample')
         Capistrano::S3::Publisher.publish!('s3.amazonaws.com', 'abc', '123', 'mybucket.amazonaws.com', path, 'cf123', [], [], false, {})
@@ -42,7 +42,7 @@ describe Capistrano::S3::Publisher do
 
     context "exclusions" do
       it "exclude one files" do
-        AWS::S3::Client::V20060301.any_instance.expects(:put_object).times(7)
+        Aws::S3::Client.any_instance.expects(:put_object).times(7)
 
         path = File.join(@root, 'sample')
         exclude_paths = ['fonts/cantarell-regular-webfont.svg']
@@ -50,7 +50,7 @@ describe Capistrano::S3::Publisher do
       end
 
       it "exclude multiple files" do
-        AWS::S3::Client::V20060301.any_instance.expects(:put_object).times(6)
+        Aws::S3::Client.any_instance.expects(:put_object).times(6)
 
         path = File.join(@root, 'sample')
         exclude_paths = ['fonts/cantarell-regular-webfont.svg', 'fonts/cantarell-regular-webfont.svg.gz']
@@ -58,7 +58,7 @@ describe Capistrano::S3::Publisher do
       end
 
       it "exclude directory" do
-        AWS::S3::Client::V20060301.any_instance.expects(:put_object).times(0)
+        Aws::S3::Client.any_instance.expects(:put_object).times(0)
 
         path = File.join(@root, 'sample')
         exclude_paths = ['fonts/**/*']

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 require 'capistrano/s3/publisher'
 require 'mocha/api'
 
-AWS.stub!
+Aws.config[:stub_responses] = true
 
 RSpec.configure do |config|
   config.mock_framework = :mocha


### PR DESCRIPTION
- AWS SDK needed to be updated (2.6)
- Added s3:wait_for_invalidation task which will exit when the invalidation is completed