### PR TITLE
Add option to specify target_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,25 @@ with:
 set :region, 'eu-west-1'
 ```
 
+### Deployment path
+
+You can set `deployment_path` to select the **local** path to deploy relative to the project root. Do not use trailing slash. Default value is: `public`.
+
+```ruby
+set :deployment_path, 'dist'
+```
+
+### Target path
+
+You can also set a **remote** path relative to the bucket root using `target_path`. Do not use trailing slash. Default value is empty (bucket root).
+
+```ruby
+set :target_path, 'app'
+```
+
 ### Write options
 
-capistrano-s3 sets files `:content_type` and `:acl` to `:public_read`, add or override with:
+capistrano-s3 sets files `:content_type` and `:acl` to `public-read`, add or override with:
 
 ```ruby
 set :bucket_write_options, {
@@ -110,6 +126,8 @@ set :redirect_options, {
   'another.html' => '/test.html',
 }
 ```
+
+The `redirect_options` parameter takes `target_path` into account, you can use the same paths regardless of its value.
 
 Valid redirect destination should either start with `http` or `https` scheme,
 or begin with leading slash `/`.
@@ -137,6 +155,14 @@ If you set a CloudFront distribution ID (not the URL!) and an array of paths, ca
 ```ruby
 set :distribution_id, "CHANGETHIS"
 set :invalidations, [ "/index.html", "/assets/*" ]
+```
+
+The CloudFront invalidation feature takes `target_path` into account. Write your invalidations relatively to your `target_path`. For example to invalidate everything inside the remote `app` folder:
+
+```ruby
+set :target_path, "app"
+set :distribution_id, "CHANGETHIS"
+set :invalidations, [ "/*" ]
 ```
 
 If you want to wait until the invalidation batch is completed (e.g. on a CI server), you can run `cap <stage> deploy:s3:wait_for_invalidation`. The command will wait indefinitely until the invalidation is completed.

--- a/lib/capistrano/s3/defaults.rb
+++ b/lib/capistrano/s3/defaults.rb
@@ -3,7 +3,8 @@ module Capistrano
     module Defaults
       DEFAULTS = {
         :deployment_path      => "public",
-        :bucket_write_options => { :acl => :public_read },
+        :target_path          => "",
+        :bucket_write_options => { :acl => 'public-read' },
         :region               => 'us-east-1',
         :redirect_options     => {},
         :only_gzip            => false,

--- a/lib/capistrano/tasks/capistrano_2.rb
+++ b/lib/capistrano/tasks/capistrano_2.rb
@@ -23,7 +23,7 @@ module Capistrano
         task :upload_files do
           extra_options = { :write => bucket_write_options, :redirect => redirect_options }
           S3::Publisher.publish!(region, access_key_id, secret_access_key,
-                             bucket, deployment_path, distribution_id, invalidations, exclusions, only_gzip, extra_options)
+                             bucket, deployment_path, target_path, distribution_id, invalidations, exclusions, only_gzip, extra_options)
         end
       end
 

--- a/lib/capistrano/tasks/capistrano_3.rb
+++ b/lib/capistrano/tasks/capistrano_3.rb
@@ -20,7 +20,7 @@ namespace :deploy do
     task :upload_files do
       extra_options = { :write => fetch(:bucket_write_options), :redirect => fetch(:redirect_options) }
       Capistrano::S3::Publisher.publish!(fetch(:region), fetch(:access_key_id), fetch(:secret_access_key),
-                             fetch(:bucket), fetch(:deployment_path), fetch(:distribution_id), fetch(:invalidations), fetch(:exclusions), fetch(:only_gzip), extra_options)
+                             fetch(:bucket), fetch(:deployment_path), fetch(:target_path), fetch(:distribution_id), fetch(:invalidations), fetch(:exclusions), fetch(:only_gzip), extra_options)
     end
   end
 

--- a/spec/publisher_spec.rb
+++ b/spec/publisher_spec.rb
@@ -10,12 +10,12 @@ describe Capistrano::S3::Publisher do
   context "on publish!" do
     it "publish all files" do
       Aws::S3::Client.any_instance.expects(:put_object).times(8)
-      Capistrano::S3::Publisher.publish!('s3.amazonaws.com', 'abc', '123', 'mybucket.amazonaws.com', './spec/sample', 'cf123', [], [], false, {})
+      Capistrano::S3::Publisher.publish!('s3.amazonaws.com', 'abc', '123', 'mybucket.amazonaws.com', 'spec/sample', '', 'cf123', [], [], false, {})
     end
 
     it "publish only gzip files when option is enabled" do
       Aws::S3::Client.any_instance.expects(:put_object).times(4)
-      Capistrano::S3::Publisher.publish!('s3.amazonaws.com', 'abc', '123', 'mybucket.amazonaws.com', 'spec/sample', 'cf123', [], [], true, {})
+      Capistrano::S3::Publisher.publish!('s3.amazonaws.com', 'abc', '123', 'mybucket.amazonaws.com', 'spec/sample', '', 'cf123', [], [], true, {})
     end
 
     context "invalidations" do
@@ -23,14 +23,14 @@ describe Capistrano::S3::Publisher do
         Aws::S3::Client.any_instance.expects(:put_object).times(8)
         Aws::CloudFront::Client.any_instance.expects(:create_invalidation).once
 
-        Capistrano::S3::Publisher.publish!('s3.amazonaws.com', 'abc', '123', 'mybucket.amazonaws.com', 'spec/sample/', 'cf123', ['*'], [], false, {})
+        Capistrano::S3::Publisher.publish!('s3.amazonaws.com', 'abc', '123', 'mybucket.amazonaws.com', 'spec/sample', '', 'cf123', ['*'], [], false, {})
       end
 
       it "publish all files without invalidations" do
         Aws::S3::Client.any_instance.expects(:put_object).times(8)
         Aws::CloudFront::Client.any_instance.expects(:create_invalidation).never
 
-        Capistrano::S3::Publisher.publish!('s3.amazonaws.com', 'abc', '123', 'mybucket.amazonaws.com', './spec/sample/', 'cf123', [], [], false, {})
+        Capistrano::S3::Publisher.publish!('s3.amazonaws.com', 'abc', '123', 'mybucket.amazonaws.com', 'spec/sample', '', 'cf123', [], [], false, {})
       end
     end
 
@@ -39,24 +39,22 @@ describe Capistrano::S3::Publisher do
         Aws::S3::Client.any_instance.expects(:put_object).times(7)
 
         exclude_paths = ['fonts/cantarell-regular-webfont.svg']
-        Capistrano::S3::Publisher.publish!('s3.amazonaws.com', 'abc', '123', 'mybucket.amazonaws.com', 'spec/sample', 'cf123', [], exclude_paths, false, {})
+        Capistrano::S3::Publisher.publish!('s3.amazonaws.com', 'abc', '123', 'mybucket.amazonaws.com', 'spec/sample', '', 'cf123', [], exclude_paths, false, {})
       end
 
       it "exclude multiple files" do
         Aws::S3::Client.any_instance.expects(:put_object).times(6)
 
         exclude_paths = ['fonts/cantarell-regular-webfont.svg', 'fonts/cantarell-regular-webfont.svg.gz']
-        Capistrano::S3::Publisher.publish!('s3.amazonaws.com', 'abc', '123', 'mybucket.amazonaws.com', 'spec/sample', 'cf123', [], exclude_paths, false, {})
+        Capistrano::S3::Publisher.publish!('s3.amazonaws.com', 'abc', '123', 'mybucket.amazonaws.com', 'spec/sample', '', 'cf123', [], exclude_paths, false, {})
       end
 
       it "exclude directory" do
         Aws::S3::Client.any_instance.expects(:put_object).times(0)
 
         exclude_paths = ['fonts/**/*']
-        Capistrano::S3::Publisher.publish!('s3.amazonaws.com', 'abc', '123', 'mybucket.amazonaws.com', 'spec/sample', 'cf123', [], exclude_paths, false, {})
+        Capistrano::S3::Publisher.publish!('s3.amazonaws.com', 'abc', '123', 'mybucket.amazonaws.com', 'spec/sample', '', 'cf123', [], exclude_paths, false, {})
       end
     end
-
-
   end
 end


### PR DESCRIPTION
Specify a subdirectory to upload files in target bucket

- Support for put_object operation
- Support for invalidations
- Added README clarifications

**Missing**:
- `clear!` only the selected subfolder
- test cases
