### PR TITLE
add stage name to .last_published file

### DIFF
--- a/lib/capistrano/tasks/capistrano_2.rb
+++ b/lib/capistrano/tasks/capistrano_2.rb
@@ -11,7 +11,7 @@ module Capistrano
       namespace :s3 do
         desc "Empties bucket of all files. Caution when using this command, as it cannot be undone!"
         task :empty do
-          S3::Publisher.clear!(region, access_key_id, secret_access_key, bucket)
+          S3::Publisher.clear!(stage, region, access_key_id, secret_access_key, bucket)
         end
 
         desc "Waits until the last CloudFront invalidation batch is completed"
@@ -22,7 +22,7 @@ module Capistrano
         desc "Upload files to the bucket in the current state"
         task :upload_files do
           extra_options = { :write => bucket_write_options, :redirect => redirect_options }
-          S3::Publisher.publish!(region, access_key_id, secret_access_key,
+          S3::Publisher.publish!(stage, region, access_key_id, secret_access_key,
                              bucket, deployment_path, target_path, distribution_id, invalidations, exclusions, only_gzip, extra_options)
         end
       end

--- a/lib/capistrano/tasks/capistrano_3.rb
+++ b/lib/capistrano/tasks/capistrano_3.rb
@@ -8,7 +8,7 @@ namespace :deploy do
   namespace :s3 do
     desc "Empties bucket of all files. Caution when using this command, as it cannot be undone!"
     task :empty do
-      Capistrano::S3::Publisher.clear!(fetch(:region), fetch(:access_key_id), fetch(:secret_access_key), fetch(:bucket))
+      Capistrano::S3::Publisher.clear!(fetch(:stage), fetch(:region), fetch(:access_key_id), fetch(:secret_access_key), fetch(:bucket))
     end
 
     desc "Waits until the last CloudFront invalidation batch is completed"
@@ -19,8 +19,7 @@ namespace :deploy do
     desc "Upload files to the bucket in the current state"
     task :upload_files do
       extra_options = { :write => fetch(:bucket_write_options), :redirect => fetch(:redirect_options) }
-      Capistrano::S3::Publisher.publish!(fetch(:region), fetch(:access_key_id), fetch(:secret_access_key),
-                             fetch(:bucket), fetch(:deployment_path), fetch(:target_path), fetch(:distribution_id), fetch(:invalidations), fetch(:exclusions), fetch(:only_gzip), extra_options)
+      Capistrano::S3::Publisher.publish!(fetch(:stage), fetch(:region), fetch(:access_key_id), fetch(:secret_access_key), fetch(:bucket), fetch(:deployment_path), fetch(:target_path), fetch(:distribution_id), fetch(:invalidations), fetch(:exclusions), fetch(:only_gzip), extra_options)
     end
   end
 

--- a/spec/publisher_spec.rb
+++ b/spec/publisher_spec.rb
@@ -3,19 +3,19 @@ require 'spec_helper'
 describe Capistrano::S3::Publisher do
   before do
     @root = File.expand_path('../', __FILE__)
-    publish_file = Capistrano::S3::Publisher::LAST_PUBLISHED_FILE
-    FileUtils.rm(publish_file) if File.exist?(publish_file)
+    publish_folder = Capistrano::S3::Publisher::LAST_PUBLISHED_FOLDER
+    FileUtils.rm_r(publish_folder) if File.exist?(publish_folder)
   end
 
   context "on publish!" do
     it "publish all files" do
       Aws::S3::Client.any_instance.expects(:put_object).times(8)
-      Capistrano::S3::Publisher.publish!('s3.amazonaws.com', 'abc', '123', 'mybucket.amazonaws.com', 'spec/sample', '', 'cf123', [], [], false, {})
+      Capistrano::S3::Publisher.publish!('production', 's3.amazonaws.com', 'abc', '123', 'mybucket.amazonaws.com', 'spec/sample', '', 'cf123', [], [], false, {})
     end
 
     it "publish only gzip files when option is enabled" do
       Aws::S3::Client.any_instance.expects(:put_object).times(4)
-      Capistrano::S3::Publisher.publish!('s3.amazonaws.com', 'abc', '123', 'mybucket.amazonaws.com', 'spec/sample', '', 'cf123', [], [], true, {})
+      Capistrano::S3::Publisher.publish!('production', 's3.amazonaws.com', 'abc', '123', 'mybucket.amazonaws.com', 'spec/sample', '', 'cf123', [], [], true, {})
     end
 
     context "invalidations" do
@@ -23,14 +23,14 @@ describe Capistrano::S3::Publisher do
         Aws::S3::Client.any_instance.expects(:put_object).times(8)
         Aws::CloudFront::Client.any_instance.expects(:create_invalidation).once
 
-        Capistrano::S3::Publisher.publish!('s3.amazonaws.com', 'abc', '123', 'mybucket.amazonaws.com', 'spec/sample', '', 'cf123', ['*'], [], false, {})
+        Capistrano::S3::Publisher.publish!('production', 's3.amazonaws.com', 'abc', '123', 'mybucket.amazonaws.com', 'spec/sample', '', 'cf123', ['*'], [], false, {})
       end
 
       it "publish all files without invalidations" do
         Aws::S3::Client.any_instance.expects(:put_object).times(8)
         Aws::CloudFront::Client.any_instance.expects(:create_invalidation).never
 
-        Capistrano::S3::Publisher.publish!('s3.amazonaws.com', 'abc', '123', 'mybucket.amazonaws.com', 'spec/sample', '', 'cf123', [], [], false, {})
+        Capistrano::S3::Publisher.publish!('production', 's3.amazonaws.com', 'abc', '123', 'mybucket.amazonaws.com', 'spec/sample', '', 'cf123', [], [], false, {})
       end
     end
 
@@ -39,21 +39,21 @@ describe Capistrano::S3::Publisher do
         Aws::S3::Client.any_instance.expects(:put_object).times(7)
 
         exclude_paths = ['fonts/cantarell-regular-webfont.svg']
-        Capistrano::S3::Publisher.publish!('s3.amazonaws.com', 'abc', '123', 'mybucket.amazonaws.com', 'spec/sample', '', 'cf123', [], exclude_paths, false, {})
+        Capistrano::S3::Publisher.publish!('production', 's3.amazonaws.com', 'abc', '123', 'mybucket.amazonaws.com', 'spec/sample', '', 'cf123', [], exclude_paths, false, {})
       end
 
       it "exclude multiple files" do
         Aws::S3::Client.any_instance.expects(:put_object).times(6)
 
         exclude_paths = ['fonts/cantarell-regular-webfont.svg', 'fonts/cantarell-regular-webfont.svg.gz']
-        Capistrano::S3::Publisher.publish!('s3.amazonaws.com', 'abc', '123', 'mybucket.amazonaws.com', 'spec/sample', '', 'cf123', [], exclude_paths, false, {})
+        Capistrano::S3::Publisher.publish!('production', 's3.amazonaws.com', 'abc', '123', 'mybucket.amazonaws.com', 'spec/sample', '', 'cf123', [], exclude_paths, false, {})
       end
 
       it "exclude directory" do
         Aws::S3::Client.any_instance.expects(:put_object).times(0)
 
         exclude_paths = ['fonts/**/*']
-        Capistrano::S3::Publisher.publish!('s3.amazonaws.com', 'abc', '123', 'mybucket.amazonaws.com', 'spec/sample', '', 'cf123', [], exclude_paths, false, {})
+        Capistrano::S3::Publisher.publish!('production', 's3.amazonaws.com', 'abc', '123', 'mybucket.amazonaws.com', 'spec/sample', '', 'cf123', [], exclude_paths, false, {})
       end
     end
   end


### PR DESCRIPTION
Hi,

This adds support for Capistrano stages, using one .last_published file per stage. Without this feature, if you deploy to multiple stages you might have some files deployed to the first stage and not the others.

Yann