### PR TITLE
Add ability to assume an IAM role

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,6 @@ Just add to your configuration:
 ```ruby
 set :only_gzip, true
 ```
-
 ### CloudFront invalidation
 
 If you set a CloudFront distribution ID (not the URL!) and an array of paths, capistrano-s3 will post an invalidation request. CloudFront supports wildcard invalidations. For example:
@@ -221,6 +220,14 @@ You can enable to prefer CloudFront-supported MIME types over the "best" ones by
 
 ```ruby
 set :prefer_cf_mime_types, true
+```
+
+### Assume Role
+
+Optionally, you may specify an IAM Role ARN [to assume](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html) before deploying:
+
+```ruby 
+set :assume_role, 'ROLE_ARN'
 ```
 
 ## Example of usage

--- a/lib/capistrano/s3/defaults.rb
+++ b/lib/capistrano/s3/defaults.rb
@@ -8,6 +8,7 @@ module Capistrano
         target_path: "",
         bucket_write_options: { acl: "public-read" },
         region: "us-east-1",
+        assume_role: nil,
         redirect_options: {},
         only_gzip: false,
         invalidations: [],

--- a/lib/capistrano/tasks/capistrano_2.rb
+++ b/lib/capistrano/tasks/capistrano_2.rb
@@ -31,7 +31,7 @@ module Capistrano
             object_write: object_write_options,
             prefer_cf_mime_types: prefer_cf_mime_types
           }
-          S3::Publisher.publish!(region, access_key_id, secret_access_key,
+          S3::Publisher.publish!(region, access_key_id, secret_access_key, assume_role,
                                  bucket, deployment_path, target_path, distribution_id,
                                  invalidations, exclusions, only_gzip, extra_options)
         end

--- a/lib/capistrano/tasks/capistrano_3.rb
+++ b/lib/capistrano/tasks/capistrano_3.rb
@@ -32,10 +32,11 @@ namespace :deploy do
         prefer_cf_mime_types: fetch(:prefer_cf_mime_types)
       }
       Capistrano::S3::Publisher.publish!(fetch(:region), fetch(:access_key_id),
-                                         fetch(:secret_access_key), fetch(:bucket),
-                                         fetch(:deployment_path), fetch(:target_path),
-                                         fetch(:distribution_id), fetch(:invalidations),
-                                         fetch(:exclusions), fetch(:only_gzip), extra_options,
+                                         fetch(:secret_access_key), fetch(:assume_role),
+                                         fetch(:bucket), fetch(:deployment_path),
+                                         fetch(:target_path), fetch(:distribution_id),
+                                         fetch(:invalidations), fetch(:exclusions), 
+                                         fetch(:only_gzip), extra_options,
                                          fetch(:stage))
     end
   end

--- a/spec/capistrano/s3/publisher_spec.rb
+++ b/spec/capistrano/s3/publisher_spec.rb
@@ -28,13 +28,13 @@ describe Capistrano::S3::Publisher do
   describe "publish!" do
     it "publish all files" do
       Aws::S3::Client.any_instance.expects(:put_object).times(8)
-      described_class.publish!("s3.amazonaws.com", "abc", "123", "mybucket.amazonaws.com",
+      described_class.publish!("s3.amazonaws.com", "abc", "123", nil, "mybucket.amazonaws.com",
                                "spec/sample", "", "cf123", [], [], false, {}, "staging")
     end
 
     it "publish only gzip files when option is enabled" do
       Aws::S3::Client.any_instance.expects(:put_object).times(4)
-      described_class.publish!("s3.amazonaws.com", "abc", "123", "mybucket.amazonaws.com",
+      described_class.publish!("s3.amazonaws.com", "abc", "123", nil, "mybucket.amazonaws.com",
                                "spec/sample", "", "cf123", [], [], true, {}, "staging")
     end
 
@@ -43,7 +43,7 @@ describe Capistrano::S3::Publisher do
         Aws::S3::Client.any_instance.expects(:put_object).times(8)
         Aws::CloudFront::Client.any_instance.expects(:create_invalidation).once
 
-        described_class.publish!("s3.amazonaws.com", "abc", "123", "mybucket.amazonaws.com",
+        described_class.publish!("s3.amazonaws.com", "abc", "123", nil, "mybucket.amazonaws.com",
                                  "spec/sample", "", "cf123", ["*"], [], false, {}, "staging")
       end
 
@@ -51,7 +51,7 @@ describe Capistrano::S3::Publisher do
         Aws::S3::Client.any_instance.expects(:put_object).times(8)
         Aws::CloudFront::Client.any_instance.expects(:create_invalidation).never
 
-        described_class.publish!("s3.amazonaws.com", "abc", "123", "mybucket.amazonaws.com",
+        described_class.publish!("s3.amazonaws.com", "abc", "123", nil, "mybucket.amazonaws.com",
                                  "spec/sample", "", "cf123", [], [], false, {}, "staging")
       end
     end
@@ -61,7 +61,7 @@ describe Capistrano::S3::Publisher do
         Aws::S3::Client.any_instance.expects(:put_object).times(7)
 
         exclude_paths = ["fonts/cantarell-regular-webfont.svg"]
-        described_class.publish!("s3.amazonaws.com", "abc", "123", "mybucket.amazonaws.com",
+        described_class.publish!("s3.amazonaws.com", "abc", "123", nil, "mybucket.amazonaws.com",
                                  "spec/sample", "", "cf123", [], exclude_paths, false, {},
                                  "staging")
       end
@@ -71,7 +71,7 @@ describe Capistrano::S3::Publisher do
 
         exclude_paths = ["fonts/cantarell-regular-webfont.svg",
                          "fonts/cantarell-regular-webfont.svg.gz"]
-        described_class.publish!("s3.amazonaws.com", "abc", "123", "mybucket.amazonaws.com",
+        described_class.publish!("s3.amazonaws.com", "abc", "123", nil, "mybucket.amazonaws.com",
                                  "spec/sample", "", "cf123", [], exclude_paths, false, {},
                                  "staging")
       end
@@ -80,7 +80,7 @@ describe Capistrano::S3::Publisher do
         Aws::S3::Client.any_instance.expects(:put_object).times(0)
 
         exclude_paths = ["fonts/**/*"]
-        described_class.publish!("s3.amazonaws.com", "abc", "123", "mybucket.amazonaws.com",
+        described_class.publish!("s3.amazonaws.com", "abc", "123", nil, "mybucket.amazonaws.com",
                                  "spec/sample", "", "cf123", [], exclude_paths, false, {},
                                  "staging")
       end
@@ -94,7 +94,7 @@ describe Capistrano::S3::Publisher do
         Aws::S3::Client.any_instance.expects(:put_object).with do |options|
           contains(options, headers)
         end.times(3)
-        described_class.publish!("s3.amazonaws.com", "abc", "123", "mybucket.amazonaws.com",
+        described_class.publish!("s3.amazonaws.com", "abc", "123", nil, "mybucket.amazonaws.com",
                                  "spec/sample-write", "", "cf123", [], [], false, extra_options,
                                  "staging")
       end
@@ -113,7 +113,7 @@ describe Capistrano::S3::Publisher do
         Aws::S3::Client.any_instance.expects(:put_object).with do |options|
           options[:key] != "index.html" && !contains(options, headers)
         end.twice
-        described_class.publish!("s3.amazonaws.com", "abc", "123", "mybucket.amazonaws.com",
+        described_class.publish!("s3.amazonaws.com", "abc", "123", nil, "mybucket.amazonaws.com",
                                  "spec/sample-write", "", "cf123", [], [], false, extra_options,
                                  "staging")
       end
@@ -137,7 +137,7 @@ describe Capistrano::S3::Publisher do
             !contains(options, index_headers) &&
             contains(options, asset_headers)
         end.twice
-        described_class.publish!("s3.amazonaws.com", "abc", "123", "mybucket.amazonaws.com",
+        described_class.publish!("s3.amazonaws.com", "abc", "123", nil, "mybucket.amazonaws.com",
                                  "spec/sample-write", "", "cf123", [], [], false, extra_options,
                                  "staging")
       end
@@ -161,7 +161,7 @@ describe Capistrano::S3::Publisher do
           options[:key] == "index.html" && !contains(options, js_headers) &&
             !contains(options, asset_headers)
         end.once
-        described_class.publish!("s3.amazonaws.com", "abc", "123", "mybucket.amazonaws.com",
+        described_class.publish!("s3.amazonaws.com", "abc", "123", nil, "mybucket.amazonaws.com",
                                  "spec/sample-write", "", "cf123", [], [], false, extra_options,
                                  "staging")
       end
@@ -184,7 +184,7 @@ describe Capistrano::S3::Publisher do
           options[:key] == "index.html" && !contains(options, js_headers) &&
             !contains(options, asset_headers)
         end.once
-        described_class.publish!("s3.amazonaws.com", "abc", "123", "mybucket.amazonaws.com",
+        described_class.publish!("s3.amazonaws.com", "abc", "123", nil, "mybucket.amazonaws.com",
                                  "spec/sample-write", "", "cf123", [], [], false, extra_options,
                                  "staging")
       end
@@ -195,7 +195,7 @@ describe Capistrano::S3::Publisher do
         Aws::S3::Client.any_instance.expects(:put_object).with do |options|
           options[:content_type] == "application/javascript"
         end.once
-        described_class.publish!("s3.amazonaws.com", "abc", "123", "mybucket.amazonaws.com",
+        described_class.publish!("s3.amazonaws.com", "abc", "123", nil, "mybucket.amazonaws.com",
                                  "spec/sample-mime", "", "cf123", [], [], false, {}, "staging")
       end
 
@@ -205,10 +205,19 @@ describe Capistrano::S3::Publisher do
         Aws::S3::Client.any_instance.expects(:put_object).with do |options|
           options[:content_type] == "application/javascript"
         end.once
-        described_class.publish!("s3.amazonaws.com", "abc", "123", "mybucket.amazonaws.com",
+        described_class.publish!("s3.amazonaws.com", "abc", "123", nil, "mybucket.amazonaws.com",
                                  "spec/sample-mime", "", "cf123", [], [], false, extra_options,
                                  "staging")
       end
     end
+
+    context "with assume role" do
+      it "publish all files" do
+        Aws::S3::Client.any_instance.expects(:put_object).times(8)
+        described_class.publish!("s3.amazonaws.com", "abc", "123", 'arn:aws:iam::111222333444:role/DeployRole', "mybucket.amazonaws.com",
+                                 "spec/sample", "", "", [], [], false, {}, "staging")
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Adds an optional option for specifying an IAM Role to assume before publishing files or invalidating cloudfront:

```ruby 
set :assume_role, 'ROLE_ARN'
```